### PR TITLE
 Ensure `getProperties()` is only transformed for destructuring operations

### DIFF
--- a/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.input.js
+++ b/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.input.js
@@ -3,3 +3,5 @@ let { foo, bar, baz } = this.getProperties('foo', 'bar', 'baz');
 let { foo, bar, baz } = this.nested.object.getProperties('foo', 'bar', 'baz');
 
 let { foo, barBaz } = this.getProperties('foo', 'bar.baz');
+
+let foo = this.getProperties('bar', 'baz');

--- a/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.input.js
+++ b/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.input.js
@@ -1,3 +1,5 @@
 let { foo, bar, baz } = this.getProperties('foo', 'bar', 'baz');
 
+let { foo, bar, baz } = this.nested.object.getProperties('foo', 'bar', 'baz');
+
 let { foo, barBaz } = this.getProperties('foo', 'bar.baz');

--- a/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.output.js
+++ b/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.output.js
@@ -1,3 +1,5 @@
 let { foo, bar, baz } = this;
 
+let { foo, bar, baz } = this.nested.object;
+
 let { foo, barBaz } = this.getProperties('foo', 'bar.baz');

--- a/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.output.js
+++ b/__testfixtures__/es5-getter-ember-codemod/this-dot-getProperties.output.js
@@ -3,3 +3,5 @@ let { foo, bar, baz } = this;
 let { foo, bar, baz } = this.nested.object;
 
 let { foo, barBaz } = this.getProperties('foo', 'bar.baz');
+
+let foo = this.getProperties('bar', 'baz');

--- a/es5-getter-ember-codemod.js
+++ b/es5-getter-ember-codemod.js
@@ -66,12 +66,13 @@ module.exports = function(file, api) {
         }
       })
       .filter(path => {
-        let argumentContainsDot = path.node.arguments.some(function(i) {
-          return i.value.indexOf('.') !== -1
-        });
-        let isPartOfVariableDeclaration = path.parentPath.value.type === 'VariableDeclarator'
+        // check that this is part of a destructuring operation
+        if (path.parentPath.node.type !== 'VariableDeclarator' || path.parentPath.node.id.type !== 'ObjectPattern') {
+          return false;
+        }
 
-        return isPartOfVariableDeclaration && !argumentContainsDot;
+        // check that there are no "deep" paths (e.g. "foo.bar")
+        return path.node.arguments.every(arg => arg.value.indexOf('.') === -1);
       })
       .forEach(path => {
         path.replace(


### PR DESCRIPTION
Resolves https://github.com/rondale-sc/es5-getter-ember-codemod/issues/6