### PR TITLE
Change command for running codemod in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,21 @@ test cases.
 Installation
 ------------------------------------------------------------------------------
 
-`es5-getter-ember-codemod` itself doesn't need to be installed, but you need to
-install [`jscodeshift`](https://github.com/facebook/jscodeshift) to run the
-codemod script:
+`es5-getter-ember-codemod` itself doesn't need to be installed but you can run it using:
 
 ```
-npm install -g jscodeshift
-```
+npx github:rondale-sc/es5-getter-ember-codemod ...
+``` 
 
 
 Usage
 ------------------------------------------------------------------------------
 
-You can clone/download this repository or just run the codemods from URL like
+You can clone/download this repository or just run the codemods using the command
 shown in the following example:
 
 ```
-jscodeshift -t https://rawgit.com/rondale-sc/es5-getter-ember-codemod/master/es5-getter-ember-codemod.js ./app
+npx github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js
 ```
 
 


### PR DESCRIPTION
It appears since the project was converted to use codemod-cli you can no longer use it by linking to the raw js file in github. Also as it's not an npm package you can't install it globally. The only way I could get it running was to use the following command:

```
npx github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js
```

Also as jscodeshift is now part of codemod-cli you no longer need to install it yourself.